### PR TITLE
Use embeds instead content in Discord integration

### DIFF
--- a/spec/central/support/discord_spec.rb
+++ b/spec/central/support/discord_spec.rb
@@ -4,15 +4,35 @@ describe Central::Support::Discord do
   let(:discord) { Central::Support::Discord.new("http://foo.com", "bot") }
 
   context '#payload' do
-    it 'returns a params formatted payload' do
-      expect(discord.payload("Hello World")).to eq(username: "bot", content: "Hello World")
+    it 'returns a params formatted payload when string' do
+      expect(discord.payload("Hello World"))
+        .to eq(username: "bot", embeds: [{ description: "Hello World" }])
+    end
+
+    it 'returns a params formatted payload when embed' do
+      expect(discord.payload(description: "test", color: 123))
+        .to eq(username: "bot", embeds: [{ description: "test", color: 123 }])
+    end
+
+    it 'returns a params formatted and truncated payload when string' do
+      expect(discord.payload("lorem ipsum dolor", 5))
+        .to eq(username: "bot", embeds: [{ description: "lo..." }])
+    end
+
+    it 'returns a params formatted and truncated payload when embed' do
+      expect(discord.payload({ description: "lorem ipsum dolor", color: 123 }, 10))
+        .to eq(username: "bot", embeds: [{ description: "lorem i...", color: 123 }])
     end
   end
 
   context '#send' do
+    let(:http) { double :http }
+
     it 'triggers a HTTP POST to send payload' do
       expect(Rails.env).to receive(:development?).and_return(false)
-      expect(Net::HTTP).to receive(:post_form)
+      expect(Net::HTTP).to receive(:start).and_yield(http)
+      expect(http).to receive(:request)
+
       discord.send("hello")
     end
   end


### PR DESCRIPTION
Also, uses NET HTTP Post to send data as JSON to webhook.