### PR TITLE
Fix velocity calculation when there are no delivered points on iteration

### DIFF
--- a/lib/central/support/iteration_service.rb
+++ b/lib/central/support/iteration_service.rb
@@ -112,6 +112,12 @@ module Central
           end
       end
 
+      def group_by_all_iterations
+        iterations = (1...current_iteration_number).map { |num| [num, []] }
+
+        Hash[iterations].merge(group_by_iteration)
+      end
+
       def stories_estimates(stories)
         stories.map do |story|
           if Story::ESTIMABLE_TYPES.include? story.story_type
@@ -123,7 +129,7 @@ module Central
       end
 
       def group_by_velocity
-        @group_by_velocity ||= group_by_iteration.reduce({}) do |group, iteration|
+        @group_by_velocity ||= group_by_all_iterations.reduce({}) do |group, iteration|
           group.merge(iteration.first => iteration.last.reduce(&:+))
         end
       end
@@ -150,10 +156,10 @@ module Central
       end
 
       def velocity(number_of_iterations = VELOCITY_ITERATIONS)
-        return DEFAULT_VELOCITY unless group_by_iteration.size > 0
+        return DEFAULT_VELOCITY if group_by_all_iterations.size.zero?
         @velocity ||= {}
         @velocity[number_of_iterations] ||= begin
-          number_of_iterations = group_by_iteration.size if number_of_iterations > group_by_iteration.size
+          number_of_iterations = group_by_all_iterations.size if number_of_iterations > group_by_all_iterations.size
           return 1 if number_of_iterations.zero?
 
           iterations = Statistics.slice_non_zero(group_by_velocity.values, number_of_iterations)

--- a/spec/central/support/iteration_service_spec.rb
+++ b/spec/central/support/iteration_service_spec.rb
@@ -163,9 +163,9 @@ describe Central::Support::IterationService do
         expect(service.velocity).to eq(23)
       end
 
-      it 'assures it bypasses zeroed iterations' do
-        allow(service).to receive(:group_by_velocity) { {1=>10, 2=>20, 3=>30, 4=>12, 5=>12, 6=>0, 7=>0, 8=>20, 9=>16} }
-        expect(service.velocity).to eq(16) # ( 12 + 20 + 16 ) / 3 = 16
+      it 'assures it not bypasses zeroed iterations' do
+        allow(service).to receive(:group_by_all_iterations) { {1=>[1], 2=>[1], 3=>[], 4=>[], 5=>[], 6=>[], 7=>[], 8=>[], 9=>[8, 8, 8]} }
+        expect(service.velocity).to eq(8) # ( 0 + 0 + 24 ) / 3 = 8
       end
 
       it 'should not return less than 1' do
@@ -174,7 +174,7 @@ describe Central::Support::IterationService do
       end
 
       it 'should return the default velocity' do
-        allow(service).to receive(:group_by_iteration) { {} }
+        allow(service).to receive(:group_by_all_iterations) { {} }
         expect(service.velocity).to eq(10)
       end
     end


### PR DESCRIPTION
This is supposed to solve [this issue](https://github.com/Codeminer42/cm42-central/issues/266) on cm42-central.