### PR TITLE
Consider zeroes when calculating project velocity

### DIFF
--- a/lib/central/support/iteration_service.rb
+++ b/lib/central/support/iteration_service.rb
@@ -162,7 +162,7 @@ module Central
           number_of_iterations = group_by_all_iterations.size if number_of_iterations > group_by_all_iterations.size
           return 1 if number_of_iterations.zero?
 
-          iterations = group_by_velocity.values.reverse.take(number_of_iterations)
+          iterations = Statistics.slice_to_sample_size(group_by_velocity.values, number_of_iterations)
 
           if iterations.size > 0
             velocity = (Statistics.sum(iterations) / Statistics.total(iterations)).floor
@@ -244,7 +244,7 @@ module Central
         last_iteration_number = iterations.last.number
         if calculate_worst
           std_dev                     = Statistics.standard_deviation(group_by_velocity.values, STD_DEV_ITERATIONS)
-          ten_iterations_slice        = Statistics.slice_non_zero(group_by_velocity.values, STD_DEV_ITERATIONS)
+          ten_iterations_slice        = Statistics.slice_to_sample_size(group_by_velocity.values, STD_DEV_ITERATIONS)
           mean_of_last_ten_iterations = Statistics.mean(ten_iterations_slice)
           if std_dev > 0.0 && mean_of_last_ten_iterations > 0.0
             extra_iterations            = ( std_dev * iterations.size / mean_of_last_ten_iterations ).round

--- a/lib/central/support/iteration_service.rb
+++ b/lib/central/support/iteration_service.rb
@@ -113,7 +113,7 @@ module Central
       end
 
       def group_by_all_iterations
-        iterations = (1...current_iteration_number).map { |num| [num, []] }
+        iterations = (1...current_iteration_number).map { |num| [num, [0]] }
 
         Hash[iterations].merge(group_by_iteration)
       end
@@ -162,7 +162,7 @@ module Central
           number_of_iterations = group_by_all_iterations.size if number_of_iterations > group_by_all_iterations.size
           return 1 if number_of_iterations.zero?
 
-          iterations = Statistics.slice_non_zero(group_by_velocity.values, number_of_iterations)
+          iterations = group_by_velocity.values.reverse.take(number_of_iterations)
 
           if iterations.size > 0
             velocity = (Statistics.sum(iterations) / Statistics.total(iterations)).floor

--- a/lib/central/support/statistics.rb
+++ b/lib/central/support/statistics.rb
@@ -10,7 +10,7 @@ module Central
       # assumes that enumerable is the entire population
       # sample_size is < than enumerable.size than the variance will use N - 1 to adjust for sample
       def self.variance(enumerable, sample_size = enumerable.size)
-        slice = slice_non_zero(enumerable, sample_size)
+        slice = slice_to_sample_size(enumerable, sample_size)
         total = slice.size > 1 && (total(slice) < total(enumerable)) ? total(slice) - 1 : sample_size
         mean  = mean(slice)
         sum(slice.map { |sample| (mean - sample) ** 2 }) / total
@@ -24,7 +24,7 @@ module Central
       end
 
       def self.volatility(enumerable, sample_size = enumerable.size)
-        slice = slice_non_zero(enumerable, sample_size)
+        slice = slice_to_sample_size(enumerable, sample_size)
         return 0 if slice.empty?
 
         standard_deviation(enumerable, sample_size) / mean(slice)
@@ -42,8 +42,8 @@ module Central
         enumerable.size.to_f
       end
 
-      def self.slice_non_zero(enumerable, sample_size = 3)
-        enumerable.map { |element| element == 0 ? nil : element }.compact.reverse.take(sample_size)
+      def self.slice_to_sample_size(enumerable, sample_size = 3)
+        enumerable.reverse.take(sample_size)
       end
     end
   end

--- a/spec/central/support/iteration_service_spec.rb
+++ b/spec/central/support/iteration_service_spec.rb
@@ -164,7 +164,7 @@ describe Central::Support::IterationService do
       end
 
       it 'assures it not bypasses zeroed iterations' do
-        allow(service).to receive(:group_by_all_iterations) { {1=>[1], 2=>[1], 3=>[], 4=>[], 5=>[], 6=>[], 7=>[], 8=>[], 9=>[8, 8, 8]} }
+        allow(service).to receive(:group_by_all_iterations) { {1=>[8], 2=>[8], 3=>[0], 4=>[0], 5=>[0], 6=>[0], 7=>[0], 8=>[0], 9=>[8, 8, 8]} }
         expect(service.velocity).to eq(8) # ( 0 + 0 + 24 ) / 3 = 8
       end
 


### PR DESCRIPTION
The problem was that `Statistics.slice_non_zero` was still being called when calculating a project velocity. So, if we had sprints like these:

```ruby
[8, 8, nil, nil, nil, nil, 24]
```

It was returning the following array:

```ruby
[24, 8, 8]
```

When what we need to properly calculate the velocity was:

```ruby
[24, 0, 0]
```