### PR TITLE
Fixing volatility calculation

### DIFF
--- a/lib/central/support/statistics.rb
+++ b/lib/central/support/statistics.rb
@@ -26,8 +26,11 @@ module Central
       def self.volatility(enumerable, sample_size = enumerable.size)
         slice = slice_to_sample_size(enumerable, sample_size)
         return 0 if slice.empty?
+        
+        mean = mean(slice)
+        return 0 if mean.zero?
 
-        standard_deviation(enumerable, sample_size) / mean(slice)
+        standard_deviation(enumerable, sample_size) / mean
       end
 
       def self.to_float(enumerable)

--- a/spec/central/support/iteration_service_spec.rb
+++ b/spec/central/support/iteration_service_spec.rb
@@ -244,6 +244,10 @@ describe Central::Support::IterationService do
 
       volatility = service.volatility # population (no variance correction)
       expect("%.4f" % volatility).to eq("0.3816")
+
+      # must return 0 if there is no accepted stories on the project
+      allow(service).to receive(:group_by_velocity) { Hash[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+      expect(service.volatility).to eq(0)
     end
 
     it '#backlog_date' do


### PR DESCRIPTION
When there is no stories accepted in the last 10 iterations, the
volatility calculation is making a division by zero, resulting in a NaN. 

I've add a check to ensure it will return 0 instead of making
the division

- Fix volatity calculation
- Added a test case to cover the bugfix