### PR TITLE
Adding support to docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.gem
 Gemfile.lock
 coverage
+spec/support/rails_app/config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install: gem install bundler -v 1.12.5
 
 before_script:
   - "cd spec/support/rails_app"
+  - "cp config/database.yml.sample config/database.yml"
+  - "sed -i '/host*/d' config/database.yml && sed -i '/username*/d' config/database.yml && sed -i '/password*/d' config/database.yml"
   - "bundle install"
   - "cd ../../.."
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+from ruby:2.3.1
+
+env DEBIAN_FRONTEND noninteractive
+
+copy . /tmp/cm42-central-support
+
+run sed -i '/deb-src/d' /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get install -y build-essential postgresql-client && \
+  gem install bundler && cd /tmp/cm42-central-support/spec/support/rails_app && bundle install
+
+workdir /app

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Using Docker
+
+To setup the gem with docker you can execute the following steps:
+
+```
+cp spec/support/rails_app/config/database.yml.sample spec/support/rails_app/config/database.yml
+docker-compose build
+docker-compose up
+```
+
+This will build the image and start the postgres and the app container. The app container will keep running with a `tail -f /dev/null` command, since the gem doesn't run with a server, like an traditional rails app.
+
+To execute the tests you can run (in other shell, while the container is up) the command:
+
+```
+docker-compose exec app rspec
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Codeminer-42/central-support.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+
+services:
+  postgres:
+    image: postgres
+    volumes:
+      - db:/var/lib/postgresql/data
+    expose:
+      - '5432'
+    environment:
+      POSTGRES_DB: 'central_support_test'
+
+  app:
+    build: .
+    volumes:
+      - .:/app
+    links:
+      - postgres
+    command: bash -c "echo \"Container Started\" && tail -f /dev/null"
+
+volumes:
+  db:

--- a/spec/support/rails_app/config/database.yml.sample
+++ b/spec/support/rails_app/config/database.yml.sample
@@ -7,6 +7,9 @@ development:
 
 test:
   adapter: postgresql
+  host: postgres
+  username: postgres
+  password: postgres
   encoding: unicode
   database: central_support_test
   pool: 5


### PR DESCRIPTION
To run the tests on the project, is necessary to have a postgres server
to connect. To make this process more easy to developers, we've added
support to docker. This way is not needed to install a postgres server
on the local machine.