### PR TITLE
Adding gitlab to VALID_INTEGRATIONS

### DIFF
--- a/lib/central/support/concerns/integration_concern.rb
+++ b/lib/central/support/concerns/integration_concern.rb
@@ -4,7 +4,7 @@ module Central
       extend ActiveSupport::Concern
 
       included do
-        VALID_INTEGRATIONS = ['discord','mattermost','slack']
+        VALID_INTEGRATIONS = %w[discord mattermost slack gitlab].freeze
 
         belongs_to :project
         validates :project, presence: true


### PR DESCRIPTION
Adding gitlab to VALID_INTEGRATIONS constant on integration concern in order to implement it on the central app