### PR TITLE
Ensure correct time zone

### DIFF
--- a/lib/central/support/concerns/project_concern/csv.rb
+++ b/lib/central/support/concerns/project_concern/csv.rb
@@ -4,7 +4,7 @@ module Central
       module CSV
         module InstanceMethods
           def csv_filename
-            "#{name}-#{Time.now.strftime('%Y%m%d_%I%M')}.csv"
+            "#{name}-#{Time.current.strftime('%Y%m%d_%I%M')}.csv"
           end
         end
 


### PR DESCRIPTION
# Time zone in CSV file names

### Issue
`Time.now` is not a good practice in Ruby because the method doesn't regularize the time zone, on the contrary of `Time.current` or `Time.zone.now`.

### Chore
Refactor how the CSV file names are set to ensure the time zone is correct.