### PR TITLE
Unestimable release type

### DIFF
--- a/lib/central/support/concerns/story_concern/validations.rb
+++ b/lib/central/support/concerns/story_concern/validations.rb
@@ -12,32 +12,30 @@ module Central
           validates :owned_by_id, belongs_to_project: true
 
           ESTIMABLE_TYPES = %w[feature].freeze
-          STORY_TYPES = %i[feature chore bug release].freeze
+          STORY_TYPES     = %i[feature chore bug release].freeze
 
           extend Enumerize
           enumerize :story_type, in: STORY_TYPES, predicates: true, scope: true
           validates :story_type, presence: true
           validates :estimate, estimate: true, allow_nil: true
 
-          validate :bug_chore_estimation
+          validate :validate_non_estimable_story
         end
 
         # Returns true or false based on whether the story has been estimated.
         def estimated?
-          !estimate.nil?
+          estimate.present?
         end
-        alias :estimated :estimated?
 
         # Returns true if this story can have an estimate made against it
-        def estimable?
-          feature? && !estimated?
+        def estimable_type?
+          ESTIMABLE_TYPES.include? story_type
         end
-        alias :estimable :estimable?
 
-        def bug_chore_estimation
-          if !ESTIMABLE_TYPES.include?(story_type) && estimated?
-            errors.add(:estimate, :cant_estimate)
-          end
+        private
+
+        def validate_non_estimable_story
+          errors.add(:estimate, :cant_estimate) if !estimable_type? && estimated?
         end
       end
     end

--- a/lib/central/support/concerns/story_concern/validations.rb
+++ b/lib/central/support/concerns/story_concern/validations.rb
@@ -11,7 +11,7 @@ module Central
           validates :requested_by_id, belongs_to_project: true
           validates :owned_by_id, belongs_to_project: true
 
-          ESTIMABLE_TYPES = %w[feature release]
+          ESTIMABLE_TYPES = %w[feature].freeze
           STORY_TYPES = %i[feature chore bug release].freeze
 
           extend Enumerize

--- a/spec/central/support/story_spec.rb
+++ b/spec/central/support/story_spec.rb
@@ -60,18 +60,20 @@ describe Story, type: :model do
         expect(subject.errors[:estimate].size).to eq(1)
       end
 
-      it 'must be invalid for bug stories' do
-        subject.story_type = 'bug'
-        subject.estimate = 2
+      context 'when try to estimate' do
+        %w[chore bug release].each do |type|
+          context "a #{type} story" do
+            before { subject.attributes = { story_type: type, estimate: 1 } }
 
-        expect(subject).to_not be_valid
-      end
+            it { is_expected.to be_invalid }
+          end
+        end
 
-      it 'must be invalid for chore stories' do
-        subject.story_type = 'chore'
-        subject.estimate = 1
+        context 'a feature story' do
+          before { subject.attributes = { story_type: 'feature', estimate: 1 } }
 
-        expect(subject).to_not be_valid
+          it { is_expected.to be_valid }
+        end
       end
     end
   end
@@ -98,37 +100,32 @@ describe Story, type: :model do
   end
 
   describe '#estimated?' do
-    context 'when estimate is nil' do
+    context 'when the story estimation is nil' do
       before { subject.estimate = nil }
+
       it { is_expected.not_to be_estimated }
     end
 
-    context 'when estimate is not nil' do
-      before { subject.estimate = 0 }
+    context 'when the story estimation is 1' do
+      before { subject.estimate = 1 }
+
       it { is_expected.to be_estimated }
     end
   end
 
-  describe '#estimable?' do
-    context 'when story is a feature' do
-      before { subject.story_type = 'feature' }
+  describe '#estimable_type?' do
+    %w[chore bug release].each do |type|
+      context "when is a #{type} story" do
+        before { subject.story_type = type }
 
-      context 'when estimate is nil' do
-        before { subject.estimate = nil }
-        it { is_expected.to be_estimable }
-      end
-
-      context 'when estimate is not nil' do
-        before { subject.estimate = 0 }
-        it { is_expected.not_to be_estimable }
+        it { is_expected.not_to be_estimable_type }
       end
     end
 
-    %w[chore bug release].each do |story_type|
-      specify "a #{story_type} is not estimable" do
-        subject.story_type = story_type
-        expect(subject).not_to be_estimable
-      end
+    context 'when is a feature story' do
+      before { subject.story_type = 'feature' }
+
+      it { is_expected.to be_estimable_type }
     end
   end
 


### PR DESCRIPTION
# Remove release from story estimable types

### Feature
Release types is no longer an estimable story type (to be true I don't know why that was counting as one yet) so it is removed from the estimable story types.

Add more tests to the story model and improve code readability.